### PR TITLE
Remove Language Code from Google Cloud

### DIFF
--- a/controller.sample.conf
+++ b/controller.sample.conf
@@ -171,7 +171,6 @@ region_name=us-east-1
 [google_cloud]
 ssml_enabled=False
 key_file=
-language_code=en-US
 voice=en-US-Wavenet-A
 #pitch can be between -20.0 and 20.0, 0.0 is default pitch for chosen voice
 voice_pitch=0.0

--- a/tts/google_cloud.py
+++ b/tts/google_cloud.py
@@ -42,7 +42,7 @@ def setup(robot_config):
         hwNum = robot_config.get('tts', 'speaker_num')
     else:
         hwNum = robot_config.getint('tts', 'hw_num')
-    languageCode = voice[:4]
+    languageCode = voice[:5]
     voicePitch = robot_config.getfloat('google_cloud', 'voice_pitch')
     voiceSpeakingRate = robot_config.getfloat(
         'google_cloud', 'voice_speaking_rate')

--- a/tts/google_cloud.py
+++ b/tts/google_cloud.py
@@ -42,7 +42,7 @@ def setup(robot_config):
         hwNum = robot_config.get('tts', 'speaker_num')
     else:
         hwNum = robot_config.getint('tts', 'hw_num')
-    languageCode = robot_config.get('google_cloud', 'language_code')
+    languageCode = voice[:4]
     voicePitch = robot_config.getfloat('google_cloud', 'voice_pitch')
     voiceSpeakingRate = robot_config.getfloat(
         'google_cloud', 'voice_speaking_rate')


### PR DESCRIPTION
The user no longer needs to input the language code (i.e. `en-US`) separately from the voice (i.e. `en-us-Wavenet-A`)

Tested working.