### PR TITLE
socketio replaced with websocket_client==0.56.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-socketIO-client==0.7.2
+websocket_client==0.56.0
 configparser==3.5.0
 logging==0.4.9.6


### PR DESCRIPTION
As discussed on #remo-general in Discord, controller.py gave me a ModuleNotFoundError for module named 'websocket':

```
~/remotv/controller $ python3 controller.py
Traceback (most recent call last):
  File "controller.py", line 10, in <module>
    import networking
  File "/home/pi/remotv/controller/networking.py", line 9, in <module>
    import websocket
ModuleNotFoundError: No module named 'websocket'
```

Ged has suggested the requirements.txt is wrong as we're no longer using socketio:

```
[Ged] the requirements are wrong
https://github.com/remotv/controller/blob/master/requirements.txt

no longer uses socketio
socketIO-client==0.7.2   needs changed to   websocket_client==0.56.0
```