### PR TITLE
Main site transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ gpio.conf
 \#*\#
 .\#*
 
+# Ignore Python Virtualenvironment
+bin/
+lib/
+lib64
+share/
+pyvenv.cfg
+
 *.bak
 *.log
 *.log.1

--- a/controller.sample.conf
+++ b/controller.sample.conf
@@ -327,11 +327,11 @@ num_backup=2
 # This is mostly stuff you probably shouldn't be touching
 [misc]
 # host server to connect to
-server = dev.remo.tv
+server = remo.tv
 # API version is the version of the API.
 api_version  = dev
 # video server to connect to so you can use local websocket and remote video server
-video_server = dev.remo.tv
+video_server = remo.tv
 # Enable the controller to look for custom handler code
 custom_hardware = True
 # Enable the controller to look for custom TTS handler code

--- a/networking.py
+++ b/networking.py
@@ -41,7 +41,7 @@ ipAddr = None
 ood = None
 
 def getChatChannels(host):
-    url = 'http://%s:3231/api/%s/channels/list/%s' % (server, version, host)
+    url = 'https://%s/api/%s/channels/list/%s' % (server, version, host)
     response = robot_util.getWithRetry(url)
     log.debug("getChatChannels : %s", response)
     return json.loads(response)
@@ -147,8 +147,8 @@ def setupWebSocket(robot_config, onHandleMessage):
             bootMessage = bootMessage + ". Git repo is behind by {}.".format(commits.group(0))
 
 #    log.info("using socket io to connect to control %s", controlHostPort)
-    log.info("configuring web socket ws://%s:3231/" % server)
-    webSocket = websocket.WebSocketApp("ws://%s:3231/" % server,
+    log.info("configuring web socket wss://%s/" % server)
+    webSocket = websocket.WebSocketApp("wss://%s/" % server,
                                 on_message=onHandleMessage,
                                 on_error=onHandleWebSocketError,
                                 on_open=onHandleWebSocketOpen,
@@ -175,7 +175,7 @@ def sendChatMessage(message):
 
 def isInternetConnected():
     try:
-        url = 'http://{}:3231'.format(server)
+        url = 'https://{}'.format(server)
         urllib2.urlopen(url, timeout=1)
         log.debug("Server Detected")
         return True

--- a/video/ffmpeg.py
+++ b/video/ffmpeg.py
@@ -257,7 +257,7 @@ def startVideoCapture():
                         ' -r 25 {in_options} -i {video_device} {video_filter}'
                         ' -f mpegts -codec:v {video_codec} -b:v {video_bitrate}k -bf 0'
                         ' -muxdelay 0.001 {out_options}'
-                        ' http://{server}:1567/transmit?name={channel}-video')
+                        ' http://{server}/transmit?name={channel}-video')
                         
        videoCommandLine = videoCommandLine.format(ffmpeg=ffmpeg_location,
                             input_format=video_input_format,
@@ -303,7 +303,7 @@ def startAudioCapture():
     audioCommandLine += (' {in_options} -i {audio_device} -f mpegts'
                          ' -codec:a {audio_codec}  -b:a {audio_bitrate}k'
                          ' -muxdelay 0.001 {out_options}'
-                         ' http://{server}:1567/transmit?name={channel}-audio')
+                         ' http://{server}/transmit?name={channel}-audio')
 
     audioCommandLine = audioCommandLine.format(ffmpeg=ffmpeg_location,
                             audio_input_format=audio_input_format,


### PR DESCRIPTION
Before this gets pushed I just want to make sure that everything is as it should to successfully transition out of the `dev` subdomain. Here's what Ged said about what changed.

> In like a week ill disable direct access to the services, By then everyone should access everything with https://remo.tv/ without any port with the only exception being transmitting video which you should remove the port but just do http://remo.tv/transmit not https.
wss://remo.tv for websocket