### PR TITLE
Config refactor

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -46,8 +46,8 @@ except ImportError:
     sys.exit()
 
 try: 
-    with open('controller.conf', 'r') as fp:
-        robot_config.readfp(fp)
+    # Values in controller.conf will overwrite values in controller.sample.conf
+    robot_config.read(['controller.sample.conf', 'controller.conf'])
 except IOError:
     print("unable to read controller.conf, please check that you have copied controller.sample.conf to controller.conf and modified it appropriately.")
     sys.exit()

--- a/controller.sample.conf
+++ b/controller.sample.conf
@@ -344,6 +344,8 @@ num_backup=2
 [misc]
 # host server to connect to
 server = remo.tv
+# API server to connect to. This is needed for testing on local instances.
+api_server = remo.tv
 # API version is the version of the API.
 api_version  = dev
 # video server to connect to so you can use local websocket and remote video server
@@ -362,6 +364,8 @@ watchdog = True
 # Enable async handling of commands, your handler will either need to be able to
 # function asyncronously or it will need it's own blocking.
 enable_async=False
+# Local instances will not use secure HTTP or WebSockets
+secure_server=True
 
 # Periodically check internet connection status, and report failure / connect
 # over tts


### PR DESCRIPTION
I've made it so ConfigParser reads `controller.sample.conf` before reading `controller.conf`. This will allow the controller to fall back to the sample config file for missing options.

This also has modifications to `networking.py` to allow easier transitioning from the production server to a local instance. When I was working on getting Beee transplanted for Jill, I had to modify basically all of the URLs to get it to work.