### PR TITLE
download link corrected

### DIFF
--- a/hardware/thunderborg.py
+++ b/hardware/thunderborg.py
@@ -12,7 +12,7 @@ except:
     log.critical(
         'Cannot start ThunderBorg. ThunderBorgLib.py missing. Do the following')
     log.critical(
-        'wget -O ~/examples.zip http://www.piborg.org/downlaods/thunderborg/examples.zip')
+        'wget -O ~/examples.zip http://www.piborg.org/downloads/thunderborg/examples.zip')
     log.critical('unzip ~/examples.zip')
     log.critical(
         'cp ~/examples/ThunderBorg.py ~/remotv/hardware/ThunderBorgLib.py')


### PR DESCRIPTION
Download link in the log text was incorrect and if followed was resulting in a 404 error on the Piborg site, 'downlaods' changed to 'downloads'