### PR TITLE
Add eSpeak path + FFMPEG windows fix

### DIFF
--- a/controller.sample.conf
+++ b/controller.sample.conf
@@ -61,7 +61,8 @@ mic_device=
 [ffmpeg]
 # Combined ffmpeg options for audio and video
 ffmpeg_location = /usr/bin/ffmpeg
-#ffmpeg_location = c://ffmpeg//bin//ffmpeg.exe # Windows path example
+# Windows path example
+#ffmpeg_location = c://ffmpeg//bin//ffmpeg.exe 
 
 # Path to v4l2-ctl
 v4l2-ctl_location=/usr/bin/v4l2-ctl
@@ -168,6 +169,8 @@ voice_number=1
 # espeak path. Option setting, for when espeak is not installed in the expected
 # place.
 #espeak_path=
+# Windows path
+#espeak_path=C://Program Files (x86)//eSpeak//command_line//
 
 [festival]
 # Festival specific TTS settings go here


### PR DESCRIPTION
Didnt notice otherwise would have added this to the previous fix/patch

Added Espeak path for people who want to use eSpeak with windows