### PR TITLE
Try/Except ImportError logging and install instructions

### DIFF
--- a/hardware/adafruit_pwm.py
+++ b/hardware/adafruit_pwm.py
@@ -1,8 +1,14 @@
-import Adafruit_PCA9685
 import logging
 import time
 
 log = logging.getLogger('RemoTV.hardware.adafruit_pwm')
+
+try:
+    import Adafruit_PCA9685
+except ImportError:
+    log.critical("You need to install Adafruit_PCA9685")
+    log.critical("Please install Adafruit_PCA9685 for python and restart this script.")
+    log.critical("To install: pip install adafruit_pca9685")
 
 pwm = None
 


### PR DESCRIPTION
Added install instructions for 'adafruit_pca9685' module library, using the same style logging format as other hardware elsewhere in the Remo.TV controller repo.